### PR TITLE
Call rb_jump_tag instead of rb_exc_raise

### DIFF
--- a/ext/tk/tcltklib.c
+++ b/ext/tk/tcltklib.c
@@ -2441,7 +2441,7 @@ lib_eventloop_core(check_root, update_flag, check_var, interp)
                             if (NIL_P(rb_errinfo())) {
                                 rb_exc_raise(rb_exc_new2(rb_eFatal, "FATAL"));
                             } else {
-                                rb_exc_raise(rb_errinfo());
+                                rb_jump_tag(TAG_FATAL);
                             }
                         }
                     }


### PR DESCRIPTION
Fix suggested by Nobuyoshi Nakada: https://bugs.ruby-lang.org/issues/13297#note-2

Fixes #1

$ irb -I lib
irb(main):001:0> require 'tk'
=> true
irb(main):002:0> ^D