### PR TITLE
NameError in lib/tk/grid.rb at line 249

### DIFF
--- a/lib/tk/grid.rb
+++ b/lib/tk/grid.rb
@@ -243,7 +243,7 @@ module TkGrid
     list(tk_call_without_enc('grid', 'size', master))
   end
 
-  def slaves(master, keys=nil)
+  def slaves(master, args=nil)
     # master = master.epath if master.kind_of?(TkObject)
     master = _epath(master)
     list(tk_call_without_enc('grid', 'slaves', master, *hash_kv(args)))


### PR DESCRIPTION
Argument name seems to be wrong (initialized as 'keys', used as 'args') in slaves method, throwing a NameError no matter how the method is called
Thus I just replaced 'keys' by 'args' in the arguments list