### PR TITLE
Add msys2 library dependency tag in gem metadata

### DIFF
--- a/tk.gemspec
+++ b/tk.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rake-compiler"
+  
+  spec.metadata["msys2_mingw_dependencies"] = "tk"
 end


### PR DESCRIPTION
RubyInstaller2 supports metadata tags for installation of dependent MSYS2/MINGW libraries. The tk gem requires the mingw-w64-tk package to be installed on the system, which the gem installer takes
care about, when this tag is set.

The feature is documented here: https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#msys2-library-dependency