### PR TITLE
README: Link to other docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,49 @@ Or install it yourself as:
 
     $ gem install tk
 
+## Documentation
+
+### Read this first
+
+If you want to use Ruby/Tk (tk.rb and so on), you must have tcltklib.so
+which is working correctly. When you have some troubles on compiling,
+please read [README.tcltklib] and [README.ActiveTcl].
+
+Even if there is a tcltklib.so on your Ruby library directory, it will not
+work without Tcl/Tk libraries (e.g. libtcl8.4.so) on your environment.
+You must also check that your Tcl/Tk is installed properly.
+
+--------------------------------------------
+
+Ruby/Tk (tk.rb など) を使いたい場合には，tcltklib.so が正しく動いていな
+ければなりません．コンパイル時に何か問題が生じた場合は，[README.tcltklib]
+や [README.ActiveTcl] を見てください．
+
+たとえ Ruby のライブラリディレクトリに tcltklib.so が存在していたとして
+も，実行環境に Tcl/Tk ライブラリ (libtcl8.4.so など) がなければ機能しま
+せん．Tcl/Tk が正しくインストールされているかもチェックしてください．
+
+<tt>==========================================================
+                Hidetoshi NAGAI (nagai@ai.kyutech.ac.jp)</tt>
+
+### Manual
+
+- [Manual tcltklib, in English](MANUAL_tcltklib.eng)
+- [Manual tcltklib, in Japanese](MANUAL_tcltklib.ja)
+
+### Other documents
+
+[README.tcltklib] for compilation instructions.
+
+[README.fork] is a note on forking.
+
+[README.macosx-aqua] is about MacOS X Aqua usage.
+
+[README.tcltklib]: README.tcltklib
+[README.ActiveTcl]: README.ActiveTcl
+[README.fork]: README.fork
+[README.macosx-aqua]: README.macosx-aqua
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.


### PR DESCRIPTION
This PR adds links to existing documentation, to ease use of the README for users surfing GitHub.

- echo text of README.1st inline
- link to and describe each document