### PR TITLE
Fix warnings on Ruby 2.7

### DIFF
--- a/ext/tk/extconf.rb
+++ b/ext/tk/extconf.rb
@@ -1810,8 +1810,8 @@ end
 # check header file
 print("check functions.")
 
-%w"ruby_native_thread_p rb_errinfo rb_safe_level rb_hash_lookup
- rb_proc_new rb_obj_untrust rb_obj_taint rb_set_safe_level_force
+%w"ruby_native_thread_p rb_errinfo rb_hash_lookup
+ rb_proc_new 
  rb_sourcefile rb_thread_alive_p rb_thread_check_trap_pending
  ruby_enc_find_basename
 ".each do |func|

--- a/ext/tk/old-extconf.rb
+++ b/ext/tk/old-extconf.rb
@@ -8,7 +8,6 @@ is_win32 = (/mswin|mingw|cygwin|bccwin/ =~ RUBY_PLATFORM)
 
 have_func("ruby_native_thread_p", "ruby.h")
 have_func("rb_errinfo", "ruby.h")
-have_func("rb_safe_level", "ruby.h")
 have_struct_member("struct RArray", "ptr", "ruby.h")
 have_struct_member("struct RArray", "len", "ruby.h")
 

--- a/ext/tk/tkutil/extconf.rb
+++ b/ext/tk/tkutil/extconf.rb
@@ -3,8 +3,6 @@ begin
   require 'mkmf'
 
   have_func("rb_obj_instance_exec", "ruby.h")
-  have_func("rb_obj_untrust", "ruby.h")
-  have_func("rb_obj_taint", "ruby.h")
   have_func("rb_sym2str", "ruby.h")
   have_func("rb_id2str", "ruby.h")
   have_func("rb_ary_cat", "ruby.h")

--- a/ext/tk/tkutil/tkutil.c
+++ b/ext/tk/tkutil/tkutil.c
@@ -171,13 +171,6 @@ tk_obj_untrust(self, obj)
     VALUE self;
     VALUE obj;
 {
-#ifdef HAVE_RB_OBJ_TAINT
-  rb_obj_taint(obj);
-#endif
-#ifdef HAVE_RB_OBJ_UNTRUST
-  rb_obj_untrust(obj);
-#endif
-
   return obj;
 }
 
@@ -190,7 +183,11 @@ tk_eval_cmd(argc, argv, self)
     VALUE cmd, rest;
 
     rb_scan_args(argc, argv, "1*", &cmd, &rest);
+#ifdef RB_PASS_KEYWORDS
+    return rb_eval_cmd_kw(cmd, rest, 0);
+#else
     return rb_eval_cmd(cmd, rest, 0);
+#endif
 }
 
 static VALUE
@@ -1142,7 +1139,7 @@ tcl2rb_string(self, value)
 {
     rb_check_type(value, T_STRING);
 
-    if (RSTRING_PTR(value) == (char*)NULL) return rb_tainted_str_new2("");
+    if (RSTRING_PTR(value) == (char*)NULL) return rb_str_new2("");
 
     return tkstr_to_str(value);
 }
@@ -1154,7 +1151,7 @@ tcl2rb_num_or_str(self, value)
 {
     rb_check_type(value, T_STRING);
 
-    if (RSTRING_PTR(value) == (char*)NULL) return rb_tainted_str_new2("");
+    if (RSTRING_PTR(value) == (char*)NULL) return rb_str_new2("");
 
     return rb_rescue2(tkstr_to_number, value,
                       tkstr_to_str, value,

--- a/lib/tk.rb
+++ b/lib/tk.rb
@@ -1456,7 +1456,8 @@ EOS
       TkUtil._get_eval_string(TkUtil.eval_cmd(cmd, *args))
     end
 
-    def INTERP.init_ip_env(script = Proc.new)
+    def INTERP.init_ip_env(script = (use_block = true), &block)
+      script = block if use_block
       @init_ip_env << script
       script.call(self)
     end
@@ -3399,12 +3400,12 @@ module TkBindCore
   #def bind_append(context, cmd=Proc.new, *args)
   #  Tk.bind_append(self, context, cmd, *args)
   #end
-  def bind_append(context, *args)
+  def bind_append(context, *args, &block)
     # if args[0].kind_of?(Proc) || args[0].kind_of?(Method)
-    if TkComm._callback_entry?(args[0]) || !block_given?
+    if TkComm._callback_entry?(args[0]) || !block
       cmd = args.shift
     else
-      cmd = Proc.new
+      cmd = block
     end
     Tk.bind_append(self, context, cmd, *args)
   end

--- a/lib/tk/scrollable.rb
+++ b/lib/tk/scrollable.rb
@@ -40,7 +40,8 @@ module Tk
   end
 
   module YScrollable
-    def yscrollcommand(cmd=Proc.new)
+    def yscrollcommand(cmd = (use_block = true), &block)
+      cmd = block if use_block
       configure_cmd 'yscrollcommand', cmd
       # Tk.update  # avoid scrollbar trouble
       self


### PR DESCRIPTION
Fixes taint/$SAFE warnings as well as warnings related to Proc.new without block.