### PR TITLE
Update ActiveState link in README.ActiveTcl

### DIFF
--- a/README.ActiveTcl
+++ b/README.ActiveTcl
@@ -1,6 +1,6 @@
 ActiveTcl is ActiveState's quality-assured distribution of Tcl.
 
-# see <http://www.activestate.com/Products/ActiveTcl/>
+# see <https://www.activestate.com/products/tcl/tcl-tk-modules/>
 #     <http://www.tcl.tk/>
 
 First of all, please try to configure without any options.


### PR DESCRIPTION
The [previous link](http://www.activestate.com/Products/ActiveTcl/) 404'd.

If the [proposed link](https://www.activestate.com/products/tcl/tcl-tk-modules/) isn't preferred, this link may also work: https://www.activestate.com/products/tcl/downloads/.