### PR TITLE
Avoid implicit declaration of function 'RB_OBJ_UNTRUST' in Ruby 3

### DIFF
--- a/ext/tk/extconf.rb
+++ b/ext/tk/extconf.rb
@@ -5,6 +5,8 @@
 ##############################################################
 require 'mkmf'
 
+$CFLAGS << " -DNO_TAINT" if RUBY_VERSION >= '2.7'
+
 TkLib_Config = {}
 TkLib_Config['search_versions'] =
   # %w[8.9 8.8 8.7 8.6 8.5 8.4 8.3 8.2 8.1 8.0 7.6 4.2]

--- a/ext/tk/tcltklib.c
+++ b/ext/tk/tcltklib.c
@@ -46,10 +46,14 @@ int rb_thread_check_trap_pending(void);
 #define RARRAY_AREF(a, i) RARRAY_CONST_PTR(a)[i]
 #endif
 
+#ifdef NO_TAINT
+#define RbTk_OBJ_UNTRUST(x)  do {} while (0)
+#else
 #ifdef OBJ_UNTRUST
 #define RbTk_OBJ_UNTRUST(x)  do {OBJ_TAINT(x); OBJ_UNTRUST(x);} while (0)
 #else
 #define RbTk_OBJ_UNTRUST(x)  OBJ_TAINT(x)
+#endif
 #endif
 #define RbTk_ALLOC_N(type, n) (type *)ckalloc((int)(sizeof(type) * (n)))
 


### PR DESCRIPTION
Starting in 2.7, there is no reason to taint/untrust, so just
make RbTk_OBJ_UNTRUST a no-op in Ruby 2.7+.