### PR TITLE
Fix verbose compile warnings

### DIFF
--- a/lib/multi-tk.rb
+++ b/lib/multi-tk.rb
@@ -266,7 +266,7 @@ class MultiTkIp
 
         begin
           @interp._eval_without_enc(@interp._merge_tklist('bgerror', msg))
-        rescue Exception => e
+        rescue Exception
           warn("Warning (#{self}): " + msg)
         end
       end
@@ -659,7 +659,7 @@ class MultiTkIp
       loop do
         Thread.pass
         begin
-          thread, cmd, *args = @cmd_queue.deq(true) # non-block
+          thread, _, *_ = @cmd_queue.deq(true) # non-block
         rescue ThreadError
           # queue is empty
           retry_count -= 1
@@ -928,7 +928,6 @@ class MultiTkIp
 
     @init_ip_env_queue = Queue.new
     Thread.new{
-      current = Thread.current
       loop {
         mtx, cond, ret, table, script = @init_ip_env_queue.deq
         begin
@@ -1917,7 +1916,7 @@ if (!defined?(Use_PseudoToplevel_Feature_of_MultiTkIp) ||
             top.respond_to?(:pseudo_toplevel_evaluable?) &&
             top.pseudo_toplevel_evaluable? &&
             top.respond_to?(id)
-        rescue Exception => e
+        rescue Exception
           has_top = false
         end
 
@@ -2316,7 +2315,7 @@ class << MultiTkIp
     __getip.allow_ruby_exit?
   end
 
-  def allow_ruby_exit= (mode)
+  def allow_ruby_exit=(mode)
     __getip.allow_ruby_exit = mode
   end
 
@@ -2642,7 +2641,7 @@ class MultiTkIp
     @interp.allow_ruby_exit?
   end
 
-  def allow_ruby_exit= (mode)
+  def allow_ruby_exit=(mode)
     raise SecurityError, "no permission to manipulate" unless self.manipulable?
     @interp.allow_ruby_exit = mode
   end

--- a/lib/remote-tk.rb
+++ b/lib/remote-tk.rb
@@ -270,7 +270,7 @@ class RemoteTkIp
     false
   end
 
-  def allow_ruby_exit= (mode)
+  def allow_ruby_exit=(mode)
     fail RuntimeError, 'cannot change mode of the remote interpreter'
   end
 

--- a/lib/tk.rb
+++ b/lib/tk.rb
@@ -818,7 +818,7 @@ end
 
   def _curr_cmd_id
     #id = format("c%.4d", Tk_IDs[0])
-    id = "c" + TkCore::INTERP._ip_id_ + TkComm::Tk_IDs[0]
+    "c" + TkCore::INTERP._ip_id_ + TkComm::Tk_IDs[0]
   end
   def _next_cmd_id
     TkComm::Tk_IDs.mutex.synchronize{
@@ -3487,7 +3487,7 @@ module TkTreatFont
         else
           begin
             tk_call(*(__config_cmd << "-#{optkey}" << ltn))
-          rescue => e
+          rescue
             # ignore
           end
         end
@@ -3547,7 +3547,7 @@ module TkTreatFont
         else
           begin
             tk_call(*(__config_cmd << "-#{optkey}" << knj))
-          rescue => e
+          rescue
             # ignore
           end
         end
@@ -3804,7 +3804,7 @@ module TkConfigMethod
       fail ArgumentError, "Invalid option `#{orig_slot.inspect}'"
     end
 
-    alias_name, real_name = __optkey_aliases.find{|k, v| k.to_s == slot}
+    _, real_name = __optkey_aliases.find{|k, v| k.to_s == slot}
     if real_name
       slot = real_name.to_s
     end
@@ -3948,7 +3948,7 @@ module TkConfigMethod
         fail ArgumentError, "Invalid option `#{orig_slot.inspect}'"
       end
 
-      alias_name, real_name = __optkey_aliases.find{|k, v| k.to_s == slot}
+      _, real_name = __optkey_aliases.find{|k, v| k.to_s == slot}
       if real_name
         slot = real_name.to_s
       end
@@ -4051,7 +4051,7 @@ module TkConfigMethod
         if slot
           slot = slot.to_s
 
-          alias_name, real_name = __optkey_aliases.find{|k, v| k.to_s == slot}
+          _, real_name = __optkey_aliases.find{|k, v| k.to_s == slot}
           if real_name
             slot = real_name.to_s
           end
@@ -4431,7 +4431,7 @@ module TkConfigMethod
         if slot
           slot = slot.to_s
 
-          alias_name, real_name = __optkey_aliases.find{|k,var| k.to_s == slot}
+          _, real_name = __optkey_aliases.find{|k,var| k.to_s == slot}
           if real_name
             slot = real_name.to_s
           end

--- a/lib/tk/canvastag.rb
+++ b/lib/tk/canvastag.rb
@@ -187,7 +187,7 @@ module TkcTagAccess
   #      ltag = tag1 | tag2; ltag.path => "(t1)||(t2)"
   #      ltag = tag1 ^ tag2; ltag.path => "(t1)^(t2)"
   #      ltag = - tag1;      ltag.path => "!(t1)"
-  def & (tag)
+  def &(tag)
     if tag.kind_of? TkObject
       TkcTagString.new(@c, '(' + @id + ')&&(' + tag.path + ')')
     else
@@ -195,7 +195,7 @@ module TkcTagAccess
     end
   end
 
-  def | (tag)
+  def |(tag)
     if tag.kind_of? TkObject
       TkcTagString.new(@c, '(' + @id + ')||(' + tag.path + ')')
     else
@@ -203,7 +203,7 @@ module TkcTagAccess
     end
   end
 
-  def ^ (tag)
+  def ^(tag)
     if tag.kind_of? TkObject
       TkcTagString.new(@c, '(' + @id + ')^(' + tag.path + ')')
     else

--- a/lib/tk/entry.rb
+++ b/lib/tk/entry.rb
@@ -96,7 +96,7 @@ class Tk::Entry<Tk::Label
   def value
     _fromUTF8(tk_send_without_enc('get'))
   end
-  def value= (val)
+  def value=(val)
     tk_send_without_enc('delete', 0, 'end')
     tk_send_without_enc('insert', 0, _get_eval_enc_str(val))
     val

--- a/lib/tk/grid.rb
+++ b/lib/tk/grid.rb
@@ -66,15 +66,15 @@ module TkGrid
     params = []
     args.flatten(1).each{|win|
       case win
-      when '-', ?-              # RELATIVE PLACEMENT (increase columnspan)
+      when '-', ?-.ord              # RELATIVE PLACEMENT (increase columnspan)
         params.push('-')
       when /^-+$/             # RELATIVE PLACEMENT (increase columnspan)
         params.concat(win.to_s.split(//))
-      when '^', ?^              # RELATIVE PLACEMENT (increase rowspan)
+      when '^', ?^.ord              # RELATIVE PLACEMENT (increase rowspan)
         params.push('^')
       when /^\^+$/             # RELATIVE PLACEMENT (increase rowspan)
         params.concat(win.to_s.split(//))
-      when 'x', :x, ?x, nil, '' # RELATIVE PLACEMENT (empty column)
+      when 'x', :x, ?x.ord, nil, '' # RELATIVE PLACEMENT (empty column)
         params.push('x')
       when /^x+$/             # RELATIVE PLACEMENT (empty column)
         params.concat(win.to_s.split(//))

--- a/lib/tk/itemconfig.rb
+++ b/lib/tk/itemconfig.rb
@@ -177,7 +177,7 @@ module TkItemConfigMethod
       fail ArgumentError, "Invalid option `#{orig_opt.inspect}'"
     end
 
-    alias_name, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == option}
+    _, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == option}
     if real_name
       option = real_name.to_s
     end
@@ -324,7 +324,7 @@ module TkItemConfigMethod
         fail ArgumentError, "Invalid option `#{orig_slot.inspect}'"
       end
 
-      alias_name, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
+      _, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
       if real_name
         slot = real_name.to_s
       end
@@ -429,7 +429,7 @@ module TkItemConfigMethod
         if slot
           slot = slot.to_s
 
-          alias_name, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
+          _, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
           if real_name
             slot = real_name.to_s
           end
@@ -806,7 +806,7 @@ module TkItemConfigMethod
         if slot
           slot = slot.to_s
 
-          alias_name, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
+          _, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
           if real_name
             slot = real_name.to_s
           end

--- a/lib/tk/itemfont.rb
+++ b/lib/tk/itemfont.rb
@@ -101,7 +101,7 @@ module TkTreatItemFont
               else
                 begin
                   tk_call(*(__item_config_cmd(tagid(tagOrId)) << "-#{optkey}" << fnt))
-                rescue => e
+                rescue
                   # ignore
                 end
               end
@@ -163,7 +163,7 @@ module TkTreatItemFont
         else
           begin
             tk_call(*(__item_config_cmd(tagid(tagOrId)) << "-#{optkey}" << ltn))
-          rescue => e
+          rescue
             # ignore
           end
         end
@@ -223,7 +223,7 @@ module TkTreatItemFont
         else
           begin
             tk_call(*(__item_config_cmd(tagid(tagOrId)) << "-#{optkey}" << knj))
-          rescue => e
+          rescue
             # ignore
           end
         end

--- a/lib/tk/listbox.rb
+++ b/lib/tk/listbox.rb
@@ -88,7 +88,7 @@ class Tk::Listbox<TkTextWin
     get('0', 'end')
   end
 
-  def value= (vals)
+  def value=(vals)
     unless vals.kind_of?(Array)
       fail ArgumentError, 'an Array is expected'
     end

--- a/lib/tk/menuspec.rb
+++ b/lib/tk/menuspec.rb
@@ -210,7 +210,6 @@ module TkMenuSpec
   private :_create_menu
 
   def _use_menubar?(parent)
-    use_menubar = false
     if parent.kind_of?(Tk::Root) || parent.kind_of?(Tk::Toplevel)
       true
     elsif parent.current_configinfo.has_key?('menu')

--- a/lib/tk/namespace.rb
+++ b/lib/tk/namespace.rb
@@ -257,7 +257,7 @@ class TkNamespace < TkObject
         if name =~ /^::/
           @fullname = parent + name
         else
-          @fullname = parent +'::'+ name
+          @fullname = parent + '::' + name
         end
       else
         ancestor = __tk_call('namespace', 'current')
@@ -265,7 +265,7 @@ class TkNamespace < TkObject
         if name =~ /^::/
           @fullname = ancestor + '::' + parent + name
         else
-          @fullname = ancestor + '::'+ parent +'::'+ name
+          @fullname = ancestor + '::' + parent + '::' + name
         end
       end
     else # parent == nil

--- a/lib/tk/optiondb.rb
+++ b/lib/tk/optiondb.rb
@@ -210,7 +210,6 @@ module TkOptionDB
     unless func.kind_of?(Array)
       fail ArgumentError, "method-list must be Array"
     end
-    func_str = func.join(' ')
 
     if parent.kind_of?(Class) && parent <= @@resource_proc_class
       cmd_klass = Class.new(parent)

--- a/lib/tk/optionobj.rb
+++ b/lib/tk/optionobj.rb
@@ -36,7 +36,7 @@ module Tk
 
     def _remove_win(win)
       if win.kind_of?(Array)
-        widget, method = win
+        widget, _ = win
         @observ.delete_if{|x|
           if x.kind_of?(Array)
             x[0] == widget

--- a/lib/tk/scale.rb
+++ b/lib/tk/scale.rb
@@ -102,7 +102,7 @@ class Tk::Scale<TkWindow
     get
   end
 
-  def value= (val)
+  def value=(val)
     set(val)
     val
   end

--- a/lib/tk/text.rb
+++ b/lib/tk/text.rb
@@ -326,7 +326,7 @@ class Tk::Text<TkTextWin
     _fromUTF8(tk_send_without_enc('get', "1.0", "end - 1 char"))
   end
 
-  def value= (val)
+  def value=(val)
     tk_send_without_enc('delete', "1.0", 'end')
     tk_send_without_enc('insert', "1.0", _get_eval_enc_str(val))
     val

--- a/lib/tk/validation.rb
+++ b/lib/tk/validation.rb
@@ -303,7 +303,7 @@ class TkValidateCommand
       args = args.join(' ')
       keys = klass._get_subst_key(args)
       if cmd.kind_of?(String)
-        id = cmd
+        @id = cmd
       elsif cmd.kind_of?(TkCallbackEntry)
         @id = install_cmd(cmd)
       else
@@ -318,7 +318,7 @@ class TkValidateCommand
     else
       keys, args = klass._get_all_subst_keys
       if cmd.kind_of?(String)
-        id = cmd
+        @id = cmd
       elsif cmd.kind_of?(TkCallbackEntry)
         @id = install_cmd(cmd)
       else

--- a/lib/tk/variable.rb
+++ b/lib/tk/variable.rb
@@ -27,7 +27,7 @@ class TkVariable
     TkVar_ID_TBL.mutex.synchronize{ TkVar_ID_TBL.clear }
   }
 
-  major, minor, type, patchlevel = TclTkLib.get_version
+  major, minor, _, _ = TclTkLib.get_version
   USE_OLD_TRACE_OPTION_STYLE = (major < 8) || (major == 8 && minor < 4)
 
   #TkCore::INTERP.add_tk_procs('rb_var', 'args',
@@ -1772,11 +1772,11 @@ module Tk
   begin
     INTERP._invoke_without_enc('global', 'auto_path')
     auto_path = INTERP._invoke('set', 'auto_path')
-  rescue => e
+  rescue
     begin
       INTERP._invoke_without_enc('global', 'env')
       auto_path = INTERP._invoke('set', 'env(TCLLIBPATH)')
-    rescue => e
+    rescue
       auto_path = Tk::LIBRARY
     end
   end

--- a/lib/tk/winfo.rb
+++ b/lib/tk/winfo.rb
@@ -239,7 +239,7 @@ module TkWinfo
     TkWinfo.screendepth self
   end
 
-  def TkWinfo.screenheight (win)
+  def TkWinfo.screenheight(win)
     number(tk_call_without_enc('winfo', 'screenheight', win))
   end
   def winfo_screenheight

--- a/lib/tkextlib/blt/component.rb
+++ b/lib/tkextlib/blt/component.rb
@@ -84,13 +84,13 @@ module Tk::BLT
     private :__item_pathname
 
     def axis_cget_tkstring(id, option)
-      ret = itemcget_tkstring(['axis', tagid(id)], option)
+      itemcget_tkstring(['axis', tagid(id)], option)
     end
     def axis_cget(id, option)
-      ret = itemcget(['axis', tagid(id)], option)
+      itemcget(['axis', tagid(id)], option)
     end
     def axis_cget_strict(id, option)
-      ret = itemcget_strict(['axis', tagid(id)], option)
+      itemcget_strict(['axis', tagid(id)], option)
     end
     def axis_configure(*args)
       slot = args.pop

--- a/lib/tkextlib/bwidget/progressdlg.rb
+++ b/lib/tkextlib/bwidget/progressdlg.rb
@@ -37,7 +37,7 @@ class Tk::BWidget::ProgressDlg
     @keys['textvariable'].value
   end
 
-  def text= (txt)
+  def text=(txt)
     @keys['textvariable'].value = txt
   end
 
@@ -49,7 +49,7 @@ class Tk::BWidget::ProgressDlg
     @keys['variable'].value
   end
 
-  def value= (val)
+  def value=(val)
     @keys['variable'].value = val
   end
 

--- a/lib/tkextlib/iwidgets/entryfield.rb
+++ b/lib/tkextlib/iwidgets/entryfield.rb
@@ -91,7 +91,7 @@ class Tk::Iwidgets::Entryfield
   def value
     _fromUTF8(tk_send_without_enc('get'))
   end
-  def value= (val)
+  def value=(val)
     tk_send_without_enc('delete', 0, 'end')
     tk_send_without_enc('insert', 0, _get_eval_enc_str(val))
     val

--- a/lib/tkextlib/iwidgets/promptdialog.rb
+++ b/lib/tkextlib/iwidgets/promptdialog.rb
@@ -59,7 +59,7 @@ class Tk::Iwidgets::Promptdialog
   def value
     _fromUTF8(tk_send_without_enc('get'))
   end
-  def value= (val)
+  def value=(val)
     tk_send_without_enc('delete', 0, 'end')
     tk_send_without_enc('insert', 0, _get_eval_enc_str(val))
     val

--- a/lib/tkextlib/iwidgets/spinner.rb
+++ b/lib/tkextlib/iwidgets/spinner.rb
@@ -96,7 +96,7 @@ class Tk::Iwidgets::Spinner
   def value
     _fromUTF8(tk_send_without_enc('get'))
   end
-  def value= (val)
+  def value=(val)
     tk_send_without_enc('delete', 0, 'end')
     tk_send_without_enc('insert', 0, _get_eval_enc_str(val))
     val

--- a/lib/tkextlib/tcllib/tablelist_core.rb
+++ b/lib/tkextlib/tcllib/tablelist_core.rb
@@ -212,7 +212,7 @@ class Tk::Tcllib::Tablelist
                        nil
                      else # cmd
                        tk_tcl2ruby(cmd)
-                       end
+                     end
                    })
   end
   private :__val2ruby_optkeys

--- a/lib/tkextlib/tile.rb
+++ b/lib/tkextlib/tile.rb
@@ -144,7 +144,6 @@ module Tk
       # Tcl/Tk interpreter working under Ruby/Tk.
       # Please give attention to use this method. It may conflict with
       # some definitions on Tcl/Tk scripts.
-      klass_name = self.name
       proc_name = 'LoadImages'
       if Tk::Tile::USE_TTK_NAMESPACE
         ns_list = ['::tile']

--- a/lib/tkextlib/tile/treeview.rb
+++ b/lib/tkextlib/tile/treeview.rb
@@ -32,7 +32,7 @@ module Tk::Tile::TreeviewConfig
         if slot
           slot = slot.to_s
 
-          alias_name, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
+          _, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
           if real_name
             slot = real_name.to_s
           end
@@ -203,7 +203,7 @@ module Tk::Tile::TreeviewConfig
         if slot
           slot = slot.to_s
 
-          alias_name, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
+          _, real_name = __item_optkey_aliases(tagid(tagOrId)).find{|k, v| k.to_s == slot}
           if real_name
             slot = real_name.to_s
           end

--- a/lib/tkextlib/tktable/tktable.rb
+++ b/lib/tkextlib/tktable/tktable.rb
@@ -155,7 +155,7 @@ class Tk::TkTable::CellTag
 
   def initialize(parent, keys=nil)
     @parent = @t = parent
-    @tpath - parent.path
+    @tpath = parent.path
     CellTag_ID.mutex.synchronize{
       @path = @id = CellTag_ID.join(TkCore::INTERP._ip_id_)
       CellTag_ID[1].succ!

--- a/lib/tkextlib/treectrl/tktreectrl.rb
+++ b/lib/tkextlib/treectrl/tktreectrl.rb
@@ -1294,7 +1294,7 @@ class Tk::TreeCtrl
 
   def item_state_get(item, *args)
     if args.empty?
-      list(tk_send('item', 'state', 'get', item *args))
+      list(tk_send('item', 'state', 'get', item * args))
     else
       bool(tk_send('item', 'state', 'get', item))
     end


### PR DESCRIPTION
Most of these warnings are harmless, but the first two commits are places where the verbose compile warnings pointed out what appear to be bugs in the library.  At least those two commits would benefit from review.