### PR TITLE
Default to running the event loop on the main thread

### DIFF
--- a/lib/tk.rb
+++ b/lib/tk.rb
@@ -1210,7 +1210,7 @@ module TkCore
 =end
           end
         else
-          RUN_EVENTLOOP_ON_MAIN_THREAD = false
+          RUN_EVENTLOOP_ON_MAIN_THREAD = true
         end
 
       else # Ruby 1.8.x


### PR DESCRIPTION
This provides a massive speedup. From the sound of this, you would
think this would cause blocking of the user interface while the
Ruby code runs.  However, that happens regardless of this setting,
so I'm not sure what advantages there are to running the eventloop
on a separate thread.

Fixes #26