### PR TITLE
Optimize performance of TkText#value= when prefixing/suffixing

### DIFF
--- a/lib/tk/text.rb
+++ b/lib/tk/text.rb
@@ -327,8 +327,15 @@ class Tk::Text<TkTextWin
   end
 
   def value=(val)
-    tk_send_without_enc('delete', "1.0", 'end')
-    tk_send_without_enc('insert', "1.0", _get_eval_enc_str(val))
+    enc_val = _get_eval_enc_str(val.to_s)
+    if enc_val.start_with?(value)
+      tk_send_without_enc('insert', 'end', enc_val[value.size..-1])
+    elsif val.end_with?(value)
+      tk_send_without_enc('insert', "1.0", enc_val[0...(enc_val.size - value.size)])
+    else
+      tk_send_without_enc('delete', "1.0", 'end')
+      tk_send_without_enc('insert', "1.0", enc_val)
+    end
     val
   end
 


### PR DESCRIPTION
The `TkText#value=` method is very convenient for simpler quick usage than tinkering with insert/delete manually. 

I just optimized it to avoid doing a pre-delete when suffixing or prefixing the previous value (only adding a suffix or prefix to existing value)