### PR TITLE
Removed getMultipleSaveFile 

### DIFF
--- a/README.macosx-aqua
+++ b/README.macosx-aqua
@@ -31,7 +31,7 @@ Tk.ip_eval(<<'EOS')
     }
 EOS
 
-# use a traditional dialog for Tk.getSaveFile() and Tk.getMultipleSaveFile()
+# use a traditional dialog for Tk.getSaveFile()
 Tk.ip_eval(<<'EOS')
     proc ::tk_getSaveFile {args} {
         if {$::tk_strictMotif} {

--- a/lib/tk.rb
+++ b/lib/tk.rb
@@ -1935,9 +1935,6 @@ EOS
   def getSaveFile(keys = nil)
     tk_call('tk_getSaveFile', *hash_kv(keys))
   end
-  def getMultipleSaveFile(keys = nil)
-    simplelist(tk_call('tk_getSaveFile', '-multiple', '1', *hash_kv(keys)))
-  end
 
   def chooseColor(keys = nil)
     tk_call('tk_chooseColor', *hash_kv(keys))


### PR DESCRIPTION
Concerning https://github.com/ruby/tk/issues/38, getMultipleSaveFile was removed since it does not work on any of the currently offered ActiveTcl distros (8.6 and 8.5)

