### PR TITLE
Fix patterns in extconf to terminate version number ranges.

### DIFF
--- a/ext/tk/extconf.rb
+++ b/ext/tk/extconf.rb
@@ -510,9 +510,9 @@ def get_tclConfig_dirs
       '/usr/local/opt', '/usr/local/pkg', '/usr/local/share', '/usr/local',
       '/usr/opt', '/usr/pkg', '/usr/share', '/usr/contrib', '/usr'
     ].map{|dir|
-      Dir.glob(dir + "/{tcltk,tcl,tk}[#{TkLib_Config['major_nums']}*/lib",
+      Dir.glob(dir + "/{tcltk,tcl,tk}[#{TkLib_Config['major_nums']}]*/lib",
                File::FNM_CASEFOLD)
-      Dir.glob(dir + "/{tcltk,tcl,tk}[#{TkLib_Config['major_nums']}*",
+      Dir.glob(dir + "/{tcltk,tcl,tk}[#{TkLib_Config['major_nums']}]*",
                File::FNM_CASEFOLD)
       Dir.glob(dir + '/{tcltk,tcl,tk}/lib', File::FNM_CASEFOLD)
       Dir.glob(dir + '/{tcltk,tcl,tk}', File::FNM_CASEFOLD)


### PR DESCRIPTION
While trying to install the gem on TruffleRuby we discovered some of the patterns used to find the tcl and tk locations have non-terminated ranges. On MRI these always returned false, but caused a bug in our `fnmatch` implementation. We're fixing that bug in TruffleRuby, but thought it was also worth submitting a fix here as well.