### PR TITLE
Update widget

### DIFF
--- a/sample/demos-jp/widget
+++ b/sample/demos-jp/widget
@@ -4,9 +4,9 @@
 # 漢字コード設定 ( tk.rb のロード時の encoding 推定/設定に使われる )
 #if RUBY_VERSION < '1.9.0' ### !!!!!!!!!!!!!!
 unless defined?(::Encoding.default_external)
-  $KCODE = 'euc'
+  $KCODE = 'utf-8'
 else
-  DEFAULT_TK_ENCODING = 'EUC-JP'
+  DEFAULT_TK_ENCODING = 'utf-8'
 end
 
 # tk 関係ライブラリの読み込み
@@ -888,7 +888,7 @@ def showCode1(demo)
   $code_window.iconname(file)
   code = open([$demo_dir, file].join(File::Separator), 'r'){|fid| fid.read }
   $code_text.delete('1.0', 'end')
-  code.force_encoding('EUC-JP') if defined?(::Encoding.default_external)
+  code.force_encoding('utf-8') if defined?(::Encoding.default_external)
   $code_text.insert('1.0', code)
   TkTextMarkInsert.new($code_text,'1.0')
   $set_linenum.call($code_text)
@@ -974,7 +974,7 @@ def showCode2(demo)
   $code_window.iconname(file)
   code = open([$demo_dir, file].join(File::Separator), 'r'){|fid| fid.read }
   $code_text.delete('1.0', 'end')
-  code.force_encoding('EUC-JP') if defined?(::Encoding.default_external)
+  code.force_encoding('utf-8') if defined?(::Encoding.default_external)
   $code_text.insert('1.0', code)
   TkTextMarkInsert.new($code_text,'1.0')
   $set_linenum.call($code_text)


### PR DESCRIPTION
Fix mismatch on setting of encoding. Encoding of Japanese demo files are converted from EUC-JP to UTF-8. But codes on "widget" command expect EUC-JP.