### PR TITLE
treat the default mode of eventloop thread restriction

### DIFF
--- a/lib/tk.rb
+++ b/lib/tk.rb
@@ -1158,8 +1158,16 @@ module TkCore
       opts = ''
     end
 
+    if defined? ::TK_MAINLOOP_ON_MAIN_THREAD_ONLY
+      RUN_EVENTLOOP_ON_MAIN_THREAD = ::TK_MAINLOOP_ON_MAIN_THREAD_ONLY
+    end
+
     unless self.const_defined? :RUN_EVENTLOOP_ON_MAIN_THREAD
-      RUN_EVENTLOOP_ON_MAIN_THREAD = WITH_RUBY_VM
+      if defined? ::IRB
+        RUN_EVENTLOOP_ON_MAIN_THREAD = false
+      else
+        RUN_EVENTLOOP_ON_MAIN_THREAD = WITH_RUBY_VM
+      end
     end
 
     if !WITH_RUBY_VM || RUN_EVENTLOOP_ON_MAIN_THREAD ### check Ruby 1.9 !!!!!!!


### PR DESCRIPTION
On irb, the default mode of eventloop thread control is "runnable on non-main thread", that is, "Thead.new{Tk.mainloo]" works. Probably irb users would prefer to be able to control widgets interactively.
Otherwise, the default mode is "runnable on the main thread only", because "unnable on non-main thread" requires more processing cost. To make mode selection easier, add a constant ::TK_MAINLOOP_ON_MAIN_THREAD_ONLY. By setting the value of the constant before "require 'tk'", we can select the mode of eventloop.