### PR TITLE
To fix an issue that a library/executable script needs to run the eventloop other than the main thread only when it is executed as a command.

### DIFF
--- a/lib/thread_tk.rb
+++ b/lib/thread_tk.rb
@@ -1,0 +1,8 @@
+#
+# thread_tk.rb :
+#   The eventloop of Tk (Tk.mainloop) can run on a thread other than the
+#   main thread. That is, when "require 'thread_tk'" is executed instead
+#   of or before "require 'tk'",  "Thread.new{Tk.mainloop}" works properly.
+#
+module TkCore; RUN_EVENTLOOP_ON_MAIN_THREAD = false; end
+require 'tk'

--- a/sample/demos-en/knightstour.rb
+++ b/sample/demos-en/knightstour.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby -r thread_tk
 # frozen_string_literal: false
 # Based on the widget demo of Tcl/Tk8.5.2
 # The following is the original copyright text.

--- a/sample/demos-jp/knightstour.rb
+++ b/sample/demos-jp/knightstour.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby -r thread_tk
 # -*- coding: utf-8 -*-
 # frozen_string_literal: false
 #

--- a/sample/irbtk.rb
+++ b/sample/irbtk.rb
@@ -9,6 +9,8 @@
 #   'remote-tk.rb' includes 'multi-tk.rb'.
 #   ( There is no trouble even if you give both options. )
 #
+require "thread_tk"
+
 require 'remote-tk' if ARGV.delete('--remote-tk')
 require 'multi-tk'  if ARGV.delete('--multi-tk')
 

--- a/sample/irbtkw.rbw
+++ b/sample/irbtkw.rbw
@@ -6,14 +6,13 @@
 #
 release = '2008/03/08'
 
+require 'thread_tk'
 require 'tk'
 begin
   require 'tktextio'
 rescue LoadError
   require File.join(File.dirname(File.expand_path(__FILE__)), 'tktextio.rb')
 end
-
-require 'irb'
 
 if TkCore::WITH_ENCODING
 else
@@ -110,8 +109,15 @@ def STDIN.tty?
 end
 
 # IRB setup
+require 'irb'
+
 IRB.init_config(nil)
 IRB.conf[:USE_READLINE] = false
+IRB.conf[:USE_MULTILINE] = false
+IRB.conf[:USE_SINGLELINE] = false
+IRB.conf[:USE_COLORIZE] = false
+IRB.conf[:PROMPT_MODE] = :DEFAULT
+IRB.conf[:VERBOSE] = false
 IRB.init_error
 irb = IRB::Irb.new
 IRB.conf[:MAIN_CONTEXT] = irb.context
@@ -152,5 +158,8 @@ console.bind('Control-c'){
 irb_thread.join
 
 # exit
-ev_loop.kill
-Tk.exit
+begin
+  ev_loop.kill
+  Tk.exit
+rescue
+end

--- a/sample/tktextio.rb
+++ b/sample/tktextio.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env ruby -r thread_tk
 # frozen_string_literal: false
 #
 #  TkTextIO class :: handling I/O stream on a TkText widget
@@ -394,6 +394,10 @@ class TkTextIO < TkText
   private :_block_read, :_block_write
 
   ####################################
+
+  def set_encoding(extern, intern = nil)
+    # not suppot -> do nothing
+  end
 
   def <<(obj)
     _write(obj)


### PR DESCRIPTION
When a executable Tk library script, e.g. "sample/tktextio.rb", is executed as a command, it may need to run the eventloop other than the main thread. However, when loaded as a library, it should not force the running-mode of the eventloop. "thread_tk.rb" is one solution to the problem by writing a sh-bang line like "#!/usr/bin/ruby -r thread_tk".

fix that sample/irbtkw.rbw doesn't work with the recent IRB