### PR TITLE
Make thread_tk.rb check whether tk already set to run on main thread

### DIFF
--- a/lib/thread_tk.rb
+++ b/lib/thread_tk.rb
@@ -4,5 +4,10 @@
 #   main thread. That is, when "require 'thread_tk'" is executed instead
 #   of or before "require 'tk'",  "Thread.new{Tk.mainloop}" works properly.
 #
+
+if defined?(TkCore::RUN_EVENTLOOP_ON_MAIN_THREAD) && TkCore::RUN_EVENTLOOP_ON_MAIN_THREAD
+  raise LoadError, "thread_tk.rb must be loaded before tk.rb"
+end
+
 module TkCore; RUN_EVENTLOOP_ON_MAIN_THREAD = false; end
 require 'tk'


### PR DESCRIPTION
This makes loading thread_tk error if tk has already been loaded, unless it was already loaded and has already been set not to run the event loop on the main thread.