### PR TITLE
Fix segfault in tkstr_to_float on Ruby 3.4

### DIFF
--- a/ext/tk/tkutil/tkutil.c
+++ b/ext/tk/tkutil/tkutil.c
@@ -1067,14 +1067,14 @@ static VALUE
 tkstr_to_int(value)
     VALUE value;
 {
-    return rb_cstr_to_inum(RSTRING_PTR(value), 0, 1);
+    return rb_str_to_inum(value, 0, 1);
 }
 
 static VALUE
 tkstr_to_float(value)
     VALUE value;
 {
-    return rb_float_new(rb_cstr_to_dbl(RSTRING_PTR(value), 1));
+    return rb_float_new(rb_str_to_dbl(value, 1));
 }
 
 static VALUE


### PR DESCRIPTION
I'm not sure why this fails on Ruby 3.4, but without this, I get the following failure:

```
$ ruby example.rb
/usr/local/lib/ruby/gems/3.4/gems/tk-0.5.0/lib/tk/event.rb:518: [BUG] Segmentation fault at 0x0000000000000014
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-openbsd]

-- Control frame information -----------------------------------------------
c:0014 p:---- s:0105 e:000104 CFUNC  :num_or_str
c:0013 p:---- s:0102 e:000101 CFUNC  :call
c:0012 p:---- s:0099 e:000098 CFUNC  :scan_args
...
```

I'm not sure tkstr_to_int is effected, but since it makes the code simpler, I switched it at the same time.