### PR TITLE
Turn off fail-fast in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     name: build (${{ matrix.ruby }}
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ 3.4, 3.3, 3.2, 3.1, head ]
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Fail fast makes it very difficult to determine ruby-head failures from existing version failures when users submit pull requests, since failing head causes the other jobs to fail.