### PR TITLE
Run apt-get update before apt-get install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,8 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
       run: |
-        sudo apt install tk-dev
+        sudo apt-get update
+        sudo apt-get install tk-dev
         gem install bundler --no-document
         bundle install
     - name: Run test


### PR DESCRIPTION
Switch from apt install to apt-get install, may avoid:

```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

Should hopefully fix CI failures like:

```
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/u/util-linux/uuid-dev_2.39.3-9ubuntu6.4_amd64.deb  404  Not Found [IP: 52.161.185.214 80]
65
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```