### PR TITLE
Include Tk in Tk::Tcllib::Tooltip

### DIFF
--- a/lib/tkextlib/tcllib/tooltip.rb
+++ b/lib/tkextlib/tcllib/tooltip.rb
@@ -33,6 +33,7 @@ end
 
 module Tk::Tcllib::Tooltip
   extend TkCore
+  include Tk
 
   WidgetClassName = 'Tooltip'.freeze
   WidgetClassNames[WidgetClassName] ||= self


### PR DESCRIPTION
Should fix NameError when accessing WidgetClassNames.

Fixes #86